### PR TITLE
Update DSAGenerator.cpp

### DIFF
--- a/lib/dsaGenerator/DSAGenerator.cpp
+++ b/lib/dsaGenerator/DSAGenerator.cpp
@@ -177,7 +177,7 @@ namespace dsa {
 
 offsetNames getArgFieldNames(Function &F, unsigned argNumber, StringRef argName, std::string& structName) {
 	offsetNames offNames;
-	assert((argNumber == 0) &&
+	assert((argNumber != 0) &&
 			"Request for return type information. Not supported");
 	if (argNumber > F.arg_size()) {
 		errs() << "### WARN : requested data for non-existent element\n";


### PR DESCRIPTION
getArgFieldNames(...) is only called if argNumber>0. So assert that argNumber is not 0, (rather than argNumber is 0)